### PR TITLE
Use secure URI in Homepage field.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Adam Borowski <kilobyte@angband.pl>
 Build-Depends: debhelper (>= 11~)
 Standards-Version: 4.2.0
 Rules-Requires-Root: no
-Homepage: http://github.com/kilobyte/e
+Homepage: https://github.com/kilobyte/e
 Vcs-Git: https://github.com/kilobyte/e -b debian
 Vcs-Browser: https://github.com/kilobyte/e/tree/debian
 


### PR DESCRIPTION
Use secure URI in Homepage field.

Fixes lintian: homepage-field-uses-insecure-uri
https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html
