### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: editors
 Priority: optional
 Maintainer: Adam Borowski <kilobyte@angband.pl>
 Build-Depends: debhelper-compat (= 13)
-Standards-Version: 4.5.1
+Standards-Version: 4.6.1
 Rules-Requires-Root: no
 Homepage: https://github.com/kilobyte/e
 Vcs-Git: https://github.com/kilobyte/e.git -b debian

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: editors
 Priority: optional
 Maintainer: Adam Borowski <kilobyte@angband.pl>
 Build-Depends: debhelper-compat (= 13)
-Standards-Version: 4.6.1
+Standards-Version: 4.6.2
 Rules-Requires-Root: no
 Homepage: https://github.com/kilobyte/e
 Vcs-Git: https://github.com/kilobyte/e.git -b debian

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper-compat (= 13)
 Standards-Version: 4.5.1
 Rules-Requires-Root: no
 Homepage: https://github.com/kilobyte/e
-Vcs-Git: https://github.com/kilobyte/e -b debian
+Vcs-Git: https://github.com/kilobyte/e.git -b debian
 Vcs-Browser: https://github.com/kilobyte/e/tree/debian
 
 Package: e-wrapper


### PR DESCRIPTION
Fix some issues reported by lintian

* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical))
* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

These changes have no impact on the [binary debdiff](https://janitor.debian.net/api/run/245b69fe-757e-4c24-a48b-4d8737d376ee/debdiff?filter_boring=1).

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/245b69fe-757e-4c24-a48b-4d8737d376ee/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/245b69fe-757e-4c24-a48b-4d8737d376ee/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/run/245b69fe-757e-4c24-a48b-4d8737d376ee.